### PR TITLE
[PCF] Correções finais

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ parser.tab.o
 src/*.o
 src/tabela.o
 src/ast.o
+tests/c/
+tests/bitcode/

--- a/Docs/Build.md
+++ b/Docs/Build.md
@@ -47,6 +47,9 @@ make run
 # Teste básico
 make test
 
+# Executar suíte completa de testes (48 testes em 7 categorias)
+make test-all
+
 # Criar arquivo de exemplo
 make example
 
@@ -65,6 +68,12 @@ make help
 |--------|-----------|-----|
 | `all` | Compila o compilador completo | `make all` |
 | `clean` | Remove todos os arquivos gerados, incluindo testes | `make clean` |
+| `test` | Executa teste básico com entrada padrão | `make test` |
+| `test-all` | Executa suíte completa (48 testes, 7 categorias) | `make test-all` |
+| `run` | Executa o compilador | `make run` |
+| `example` | Cria arquivo de exemplo Python | `make example` |
+| `run-example` | Compila e executa com exemplo | `make run-example` |
+| `help` | Mostra ajuda de comandos | `make help` |
 | `$(TARGET)` | Compila apenas o executável | `make compilador` |
 
 ### Arquivos Gerados
@@ -225,11 +234,11 @@ make --debug=basic
 # Compilar tudo
 make clean && make
 
-# Compilar e testar
-make clean && make && bash tests/scripts/test_category_all.sh
+# Compilar e testar (suíte completa)
+make clean && make && make test-all
 
 # Apenas recompilar e testar
-make && bash tests/scripts/test_category_all.sh
+make && make test-all
 
 # Testar categoria específica
 make && bash tests/scripts/test_category_ast.sh
@@ -237,6 +246,30 @@ make && bash tests/scripts/test_category_ast.sh
 # Compilar e executar teste individual
 make && ./compilador tests/files/ast_binop.py
 ```
+
+### Executando Suíte de Testes
+
+O comando `make test-all` executa a suíte completa de testes:
+
+```bash
+# Opção 1: Compilar e testar (recomendado para desenvolvimento)
+make clean && make && make test-all
+
+# Opção 2: Apenas testar (sem recompilar)
+make test-all
+
+# Opção 3: Teste individual (sem compilar)
+./compilador tests/files/ast_binop.py
+```
+
+**Categorias testadas:**
+- AST (10 testes)
+- Condicionais (3 testes)
+- Erros (4 testes)
+- Gerais (11 testes)
+- Símbolos (10 testes)
+- Integração (10 testes)
+- Geração de Código (48 testes: Bitcode + C)
 
 ### Automação
 
@@ -253,7 +286,7 @@ done
 
 ```bash
 # Limpar, compilar, todos os testes
-make clean && make && bash tests/scripts/test_category_all.sh
+make clean && make && make test-all
 
 # Se tudo passou, você verá:
 # [OK] AST: SUCESSO
@@ -264,6 +297,12 @@ make clean && make && bash tests/scripts/test_category_all.sh
 # [OK] INTEGRAÇÃO: SUCESSO
 # [OK] GERAÇÃO DE CÓDIGO: SUCESSO
 # Resultado: Todos os testes passaram com sucesso.
+```
+
+**No Windows (PowerShell com WSL):**
+
+```powershell
+wsl -d Ubuntu bash -lc 'cd "/mnt/c/caminho/do/projeto" && make clean && make && make test-all'
 ```
 
 ## Estrutura de Build

--- a/Docs/Build.md
+++ b/Docs/Build.md
@@ -64,7 +64,7 @@ make help
 | Target | Descrição | Uso |
 |--------|-----------|-----|
 | `all` | Compila o compilador completo | `make all` |
-| `clean` | Remove todos os arquivos gerados | `make clean` |
+| `clean` | Remove todos os arquivos gerados, incluindo testes | `make clean` |
 | `$(TARGET)` | Compila apenas o executável | `make compilador` |
 
 ### Arquivos Gerados
@@ -77,6 +77,8 @@ make help
 | `parser.output` | Relatório de conflitos do Bison | `bison -v` |
 | `*.o` | Arquivos objeto | `gcc -c` |
 | `compilador` | Executável final | `gcc -o` |
+
+**Nota:** O target `clean` remove todos esses arquivos, incluindo as pastas de testes (`tests/c/` e `tests/bitcode/`).
 
 ## Scripts Disponíveis
 

--- a/Docs/Definicoes Projeto.md
+++ b/Docs/Definicoes Projeto.md
@@ -59,7 +59,7 @@ Token Stream
 - Operadores aritméticos: `+`, `-`, `*`, `/`, `%`, `^` (exponenciação), `//` (divisão inteira)
 - Operadores comparação: `==`, `!=`, `<`, `>`, `<=`, `>=`
 - Operadores atribuição: `=`, `+=`, `-=`, `*=`, `/=`, `%=`
-- Números inteiros e ponto flutuante
+- Números inteiros e ponto flutuante (parcial, conversão para int no parser)
 - Strings com delimitadores simples/duplos
 - Comentários com `#`
 - Gerenciamento completo de indentação (INDENT/DEDENT)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ $(PARSER_C) $(PARSER_H): $(PARSER_SRC)
 clean:
 	@rm -f $(LEXER_C) $(PARSER_C) $(PARSER_H) *.o src/*.o $(TARGET) test_ast
 	@rm -f parser.output
+	@rm -rf tests/c tests/bitcode
 	@echo "🧹 Arquivos de compilação removidos"
 
 # Executar o compilador

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ test: $(TARGET)
 	@echo "Testando com entrada padrão..."
 	@echo "x = 10 + 5" | ./$(TARGET)
 
+# Executar suíte completa de testes
+test-all: $(TARGET)
+	@bash tests/scripts/test_category_all.sh
+
 # Criar arquivo de exemplo
 example:
 	@echo "x = 10 + 5" > exemplo.txt
@@ -82,6 +86,7 @@ help:
 	@echo "  make clean    - Limpar arquivos gerados"
 	@echo "  make run      - Executar o compilador"
 	@echo "  make test     - Testar com entrada padrão"
+	@echo "  make test-all - Executar suíte completa de testes (48 testes)"
 	@echo "  make example  - Criar arquivo de exemplo"
 	@echo "  make run-example - Executar com arquivo de exemplo"
 	@echo "  make help     - Mostrar esta ajuda"
@@ -121,4 +126,4 @@ test_ast: src/test_ast.c src/ast.c src/ast.h
 run_test_ast: test_ast
 	./test_ast
 
-.PHONY: all clean run test example run-example help test_ast run_test_ast
+.PHONY: all clean run test test-all example run-example help test_ast run_test_ast

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Este projeto implementa um **compilador funcional para subconjunto Python** com 
 - Operadores aritméticos: `+`, `-`, `*`, `/`, `%`, `^` (exponenciação), `//` (divisão inteira)
 - Operadores comparação: `==`, `!=`, `<`, `>`, `<=`, `>=`
 - Operadores atribuição: `=`, `+=`, `-=`, `*=`, `/=`, `%=`
-- Números inteiros e ponto flutuante
+- Números inteiros e ponto flutuante (parcial, conversão para int no parser)
 - Strings com delimitadores simples/duplos
 - Comentários com `#`
 - Gerenciamento completo de indentação (INDENT/DEDENT)

--- a/lexer/lexer.l
+++ b/lexer/lexer.l
@@ -1,6 +1,8 @@
 %x INDENT_STATE
 %option yylineno
 %option noyywrap
+%option noinput
+%option nounput
 %{
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/codegen_c.c
+++ b/src/codegen_c.c
@@ -111,8 +111,8 @@ static int eh_numero(const char *str) {
 static void limpar_nome_var(char *dest, const char *src, size_t max) {
     if (!src) return;
     
-    int j = 0;
-    for (int i = 0; src[i] && j < max - 1; i++) {
+    size_t j = 0;
+    for (size_t i = 0; src[i] && j < max - 1; i++) {
         if (isalnum(src[i]) || src[i] == '_') {
             dest[j++] = src[i];
         }
@@ -179,7 +179,7 @@ static void add_str(CodeGenC *codegen, const char *name) {
 void imprimirInstrucaoC(Instrucao *instr, CodeGenC *codegen) {
     if (!codegen || !instr) return;
     
-    char var_temp[255], arg1_clean[255], arg2_clean[255];
+    char arg1_clean[255], arg2_clean[255];
     
     switch (instr->tipo) {
         case INSTR_PARAM:

--- a/src/codegen_c.c
+++ b/src/codegen_c.c
@@ -142,6 +142,7 @@ static void add_declared(CodeGenC *codegen, const char *name) {
     codegen->declared_vars[codegen->declared_count++] = strdup(name);
 }
 
+// Helpers para controle na conversão de vetores do python para ponteiros em C
 static int is_ptr(CodeGenC *codegen, const char *name) {
     for (int i = 0; i < codegen->ptr_count; i++) {
         if (strcmp(codegen->ptr_vars[i], name) == 0) return 1;
@@ -189,7 +190,7 @@ void imprimirInstrucaoC(Instrucao *instr, CodeGenC *codegen) {
             char result_clean[255];
             limpar_nome_var(result_clean, instr->resultado, sizeof(result_clean));
             
-            Simbolo *s = buscarSimbolo(instr->arg1); // arg1 é o nome da função
+            Simbolo *s = buscarSimbolo(instr->arg1);
             
             int eh_void = (s && s->info.funcao.tipoRetorno == T_VOID);
 
@@ -215,7 +216,7 @@ void imprimirInstrucaoC(Instrucao *instr, CodeGenC *codegen) {
             limpar_nome_var(result_clean, instr->resultado, sizeof(result_clean));
             
             if (instr->arg1[0] == '"') {
-                strcpy(arg1_clean, instr->arg1); // Copia com aspas
+                strcpy(arg1_clean, instr->arg1);
             } else if (eh_numero(instr->arg1)) {
                 strcpy(arg1_clean, instr->arg1);
             } else {
@@ -229,7 +230,7 @@ void imprimirInstrucaoC(Instrucao *instr, CodeGenC *codegen) {
             if (!is_declared(codegen, result_clean)) {
                 if (is_string_assign) {
                     fprintf(codegen->arquivo, "char *%s = %s;\n", result_clean, arg1_clean);
-                    add_str(codegen, result_clean); // Marca resultado como string
+                    add_str(codegen, result_clean);
                 } 
                 else if (is_ptr(codegen, arg1_clean)) {
                     fprintf(codegen->arquivo, "int *%s = %s;\n", result_clean, arg1_clean);
@@ -277,6 +278,7 @@ void imprimirInstrucaoC(Instrucao *instr, CodeGenC *codegen) {
                 return;
             }
             
+            // Operadores aritméticos
             switch (instr->op) {
                 case '+': strcpy(op_str, "+"); break;
                 case '-': strcpy(op_str, "-"); break;
@@ -351,6 +353,7 @@ void imprimirInstrucaoC(Instrucao *instr, CodeGenC *codegen) {
         }
 
         case INSTR_ARR_GET: {
+            // Criação de vetor
             char dest[255], arr[255], idx[255];
             limpar_nome_var(dest, instr->resultado, 255);
             limpar_nome_var(arr, instr->arg1, 255);
@@ -368,6 +371,7 @@ void imprimirInstrucaoC(Instrucao *instr, CodeGenC *codegen) {
         }
 
         case INSTR_ARR_SET: {
+            // Atribuição em vetor
             char arr[255], idx[255], val[255];
             limpar_nome_var(arr, instr->resultado, 255);
             
@@ -420,6 +424,7 @@ void imprimirInstrucaoC(Instrucao *instr, CodeGenC *codegen) {
         case INSTR_FUNC_END:
             break;
         case INSTR_PRINT: {
+            // print --> printf
             imprimirIndentC(codegen);
             if (instr->arg1[0] == '\0') {
                 fprintf(codegen->arquivo, "printf(\"\\n\");\n");
@@ -438,6 +443,7 @@ void imprimirInstrucaoC(Instrucao *instr, CodeGenC *codegen) {
             break;
         }
         case INSTR_SCAN: {
+            // input --> scanf
             char result_clean[255];
             limpar_nome_var(result_clean, instr->resultado, sizeof(result_clean));
             imprimirIndentC(codegen);

--- a/src/codegen_c.h
+++ b/src/codegen_c.h
@@ -10,7 +10,6 @@ typedef struct {
     FILE *arquivo;
     int indent_level;
     int label_counter;
-    // Controle de nomes já declarados para evitar redeclarações
     char **declared_vars;
     int declared_count;
     int declared_size;

--- a/src/gerador.c
+++ b/src/gerador.c
@@ -382,7 +382,8 @@ static char *gerarCodigoExpr(NoAST *no, ListaInstrucoes *lista)
         Instrucao *instr = alocarInstrucao(INSTR_CALL);
         SAFE_STRCPY(instr->resultado, temp_dest);
         SAFE_STRCPY(instr->arg1, nome_func);
-        SAFE_STRCPY(instr->arg2, args_buffer); 
+        strncpy(instr->arg2, args_buffer, sizeof(instr->arg2) - 1);
+        instr->arg2[sizeof(instr->arg2) - 1] = '\0';
         
         adicionarInstrucao(lista, instr);
         return resultado_atual;

--- a/src/gerador.c
+++ b/src/gerador.c
@@ -194,13 +194,15 @@ Instrucao *novaInstrucaoFuncEnd(const char *nome)
     return instr;
 }
 
+// Criar instrução para parâmetros de função
 Instrucao *novaInstrucaoParam(const char *nome)
 {
     Instrucao *instr = alocarInstrucao(INSTR_PARAM);
-    SAFE_STRCPY(instr->arg1, nome); // "param nome"
+    SAFE_STRCPY(instr->arg1, nome);
     return instr;
 }
 
+// Criar instrução print
 Instrucao *novaInstrucaoPrint(const char *var)
 {
     Instrucao *instr = alocarInstrucao(INSTR_PRINT);
@@ -209,6 +211,7 @@ Instrucao *novaInstrucaoPrint(const char *var)
     return instr;
 }
 
+// Criar instrução input
 Instrucao *novaInstrucaoScan(const char *dest)
 {
     Instrucao *instr = alocarInstrucao(INSTR_SCAN);
@@ -216,12 +219,15 @@ Instrucao *novaInstrucaoScan(const char *dest)
     return instr;
 }
 
+// Instrução que inicializa um vetor
 Instrucao *novaInstrucaoArrInit(const char *dest, const char *vals) {
     Instrucao *instr = alocarInstrucao(INSTR_ARR_INIT);
     SAFE_STRCPY(instr->resultado, dest);
     SAFE_STRCPY(instr->arg1, vals);
     return instr;
 }
+
+// Instrução que recebe um vetor
 Instrucao *novaInstrucaoArrGet(const char *dest, const char *array, const char *index) {
     Instrucao *instr = alocarInstrucao(INSTR_ARR_GET);
     SAFE_STRCPY(instr->resultado, dest);
@@ -229,6 +235,8 @@ Instrucao *novaInstrucaoArrGet(const char *dest, const char *array, const char *
     SAFE_STRCPY(instr->arg2, index);
     return instr;
 }
+
+// Instrução que atribui um vetor
 Instrucao *novaInstrucaoArrSet(const char *array, const char *index, const char *val) {
     Instrucao *instr = alocarInstrucao(INSTR_ARR_SET);
     SAFE_STRCPY(instr->resultado, array);
@@ -334,6 +342,7 @@ static char *gerarCodigoExpr(NoAST *no, ListaInstrucoes *lista)
         return resultado_atual;
     }
 
+    // input/print
     if(no->op == 'C')
     {
         char *nome_func = no->esq->nome;
@@ -599,6 +608,7 @@ void gerarCodigoIntermediario(NoAST *raiz, ListaInstrucoes *lista)
         return;
     }
 
+    // While (W)
     if (raiz->op == 'W')
     {
         int label_inicio = novoLabel(lista);


### PR DESCRIPTION
## Descrição

Correções finais do compilador para melhorar qualidade de código e documentação:

### Mudanças Realizadas

- Correção de warnings durante compilação
- Adição de comentários em métodos faltantes (codegen)
- Atualização do `.gitignore` para ignorar pastas de testes geradas (`tests/c/` e `tests/bitcode/`)
- Atualização do `Makefile` para limpar pastas de testes no `make clean`
- Atualização do `Makefile` para rodar toda a suíte de testes com `make test-all`
- Documentação da limpeza de testes no `Build.md`
- Documentação do suporte parcial a ponto flutuante com conversão para int
- Documentação do comando de execução de toda a suíte de testes

### Testes

Todos os testes passando:
- AST (10/10)
- Condicionais (3/3)
- Erros (4/4)
- Gerais (11/11)
- Símbolos (10/10)
- Integração (10/10)
- Geração de Código (Bitcode + C)